### PR TITLE
Fix to the JS that makes the plugin compatible with TeamCity 2019.1

### DIFF
--- a/pullrequests/src/main/resources/buildServerResources/feature.jsp
+++ b/pullrequests/src/main/resources/buildServerResources/feature.jsp
@@ -6,7 +6,10 @@
 <script>
     BS.EditTriggersDialog.serializeParameters = function () {
         var e = BS.Util.serializeForm(this.formElement());
-        var f = Form.getInputs(this.formElement(), "password");
+        var f = Form.getInputs(this.formElement())
+            .filter(function(input) {
+                return input.type === 'password' || input.hasAttribute('data-imitate-password');
+            });
         if (!f) {
             return e;
         }

--- a/pullrequests/src/main/resources/buildServerResources/pullrequests.jsp
+++ b/pullrequests/src/main/resources/buildServerResources/pullrequests.jsp
@@ -7,7 +7,10 @@
 <script>
     BS.EditTriggersDialog.serializeParameters = function () {
         var e = BS.Util.serializeForm(this.formElement());
-        var f = Form.getInputs(this.formElement(), "password");
+        var f = Form.getInputs(this.formElement())
+            .filter(function(input) {
+                return input.type === 'password' || input.hasAttribute('data-imitate-password');
+            });
         if (!f) {
             return e;
         }

--- a/staging/src/main/resources/buildServerResources/staging_deploy.jsp
+++ b/staging/src/main/resources/buildServerResources/staging_deploy.jsp
@@ -7,7 +7,10 @@
 <script>
     BS.EditTriggersDialog.serializeParameters = function () {
         var e = BS.Util.serializeForm(this.formElement());
-        var f = Form.getInputs(this.formElement(), "password");
+        var f = Form.getInputs(this.formElement())
+            .filter(function(input) {
+                return input.type === 'password' || input.hasAttribute('data-imitate-password');
+            });
         if (!f) {
             return e;
         }


### PR DESCRIPTION
In TeamCity 2019.1 the password fields created via passwordProperty tag may have type "text" rather than "password", but are marked by additional "data-imitate-password" attribute. The plugin is relying on the field type to decide which fields get encrypted when it overrides serlializeParamers method. As it leaves all fields marked as "prop:secure" out, the passwords fields are not getting submitted by the form at all under TeamCity 2019.1.

This is a least intrusive fix to this problem that keeps the plugin compatible with the older versions as well. 

In long term the plugin authors may consider if they want to avoid overriding of serlializeParameters as it seems quite similar processing is already carried out by BS.PluginPropertiesForm.serializeParameters within TeamCity open API. 